### PR TITLE
2025 Chrome Manifest V3 Upgrade

### DIFF
--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,17 +1,31 @@
 {
-    "manifest_version": 2,
-    "name": "OpenSeadragonizer",
-    "description": "Display big images in OpenSeadragon to enable zoom and pan.",
-    "version": "1.2.3",
-    "background": {
-        "scripts": ["webextension.js"]
-    },
-    "permissions": [
-        "contextMenus"
-    ],
-    "icons": {
-        "16": "logo16.png",
-        "48": "logo48.png",
-        "128": "logo128.png"
+  "manifest_version": 3,
+  "name": "OpenSeadragonizer",
+  "version": "0.2.0",
+  "description": "Ajoute un élément au menu contextuel pour ouvrir les images dans OpenSeadragon.",
+  "homepage_url": "https://github.com/openseadragon/browser-extension",
+  "icons": {
+    "16": "common/logo16.png",
+    "48": "common/logo48.png",
+    "128": "common/logo128.png"
+  },
+  "permissions": [
+    "contextMenus"
+  ],
+  "background": {
+    "service_worker": "webextension.js"
+  },
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "common/*"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
     }
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self';"
+  }
 }


### PR DESCRIPTION
* 2025 Upgrade
manifest.json and webextension.js need to be modified to meet Google's new Manifest V3 requirements. I've created a fork and modified both files; the script and manifest are now adapted to Chrome Manifest V3.